### PR TITLE
Use absolute paths, add logging information

### DIFF
--- a/starvation.py
+++ b/starvation.py
@@ -33,13 +33,14 @@ def screenshot_finder(flag = True):
     while loop:
         for image_path in screenshots_path.iterdir():
             # establish absolute path to images the relative path does not work with pyautogui
-            absolute_image_path = f"{screenshots_path.name}/{image_path.name}"
+            absolute_image_path = str(image_path.absolute())
 
             #locate sceenshot on the single/dual screen
             screenShot = pyautogui.locateCenterOnScreen(image=absolute_image_path, confidence=0.8)
             print(screenShot)
             if screenShot is not None:
                 #close the screen
+                print(f"closing {image_path.name}")
                 pyautogui.hotkey("ctrl", "w")
                 time.sleep(5)
         loop = flag


### PR DESCRIPTION
Hi @symonkipkemei . I might be wrong about the context, but your comment mentions that you need to use absolute paths, but the current code wasn't using absolute paths.

So here's a tiny suggestion, I also added some logging info that prints the name of the identified page (gathered from the screenshot file) to the terminal.

Hope it's useful, feel free to ignore it : )